### PR TITLE
Add ConsoleHost support outside of ISE

### DIFF
--- a/Out-SquarifiedTreeMap.ps1
+++ b/Out-SquarifiedTreeMap.ps1
@@ -488,6 +488,16 @@
         Else {
             $Pipeline = $True
         }
+        
+        #region ConsoleHost Support
+        If ($host.Name -eq 'ConsoleHost') {
+            Write-Verbose "Adding assemblies for ConsoleHost support"
+            Add-Type –assemblyName PresentationFramework
+            Add-Type –assemblyName PresentationCore
+            Add-Type –assemblyName WindowsBase
+        }
+        #endregion ConsoleHost Support
+        
         Write-Verbose "[BEGIN] End Begin"
     }
     Process {


### PR DESCRIPTION
I don't use ISE so needed a way to use this without it at the console level since the WPF assemblies are only referenced in ISE automatically.

Tested in ISE to confirm compatibility.